### PR TITLE
Typo in DESCRIPTION field for bug reports

### DIFF
--- a/{{cookiecutter.repo_name}}/DESCRIPTION
+++ b/{{cookiecutter.repo_name}}/DESCRIPTION
@@ -15,4 +15,4 @@ License: {{ cookiecutter.license }}
 Encoding: UTF-8
 LazyData: true
 URL: https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.repo_name}}
-BugRepots: https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.repo_name}}/issues
+BugReports: https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.repo_name}}/issues


### PR DESCRIPTION
Simple typo fix for BugReports filed in DESCRIPTION file, as per https://cran.r-project.org/doc/manuals/R-exts.html#The-DESCRIPTION-file